### PR TITLE
[kafka] send event if consumer lag negative

### DIFF
--- a/kafka_consumer/check.py
+++ b/kafka_consumer/check.py
@@ -2,6 +2,9 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
+# stdlib
+import time
+
 # 3p
 from kafka import SimpleClient
 from kafka.structs import OffsetRequestPayload
@@ -244,12 +247,11 @@ If a value is omitted, the parent value must still be it's expected type (typica
         event_dict = {
             'timestamp': int(time.time()),
             'source_type_name': self.SOURCE_TYPE_NAME,
-            'tags': [],
+            'msg_title': title,
+            'event_type': type,
+            'msg_text': text,
+            'tags': tags,
+            'aggregation_key': aggregation_key,
         }
-        event_dict['msg_title'] = title
-        event_dict['event_type'] = type
-        event_dict['msg_text'] = text
-        event_dict['tags'] = tags
-        event_dict['aggregation_key'] = aggregation_key
 
         self.event(event_dict)

--- a/kafka_consumer/check.py
+++ b/kafka_consumer/check.py
@@ -107,7 +107,7 @@ class KafkaCheck(AgentCheck):
             for consumer_group, topics in consumer_groups.iteritems():
                 if topics is None:
                     # If topics are't specified, fetch them from ZK
-                    zk_path_topics = zk_path_topic_tmpl.format(consumer_group)
+                    zk_path_topics = zk_path_topic_tmpl.format(consumer_group=consumer_group)
                     topics = {topic: None for topic in
                         self._get_zk_path_children(zk_conn, zk_path_topics, 'topics')}
 

--- a/kafka_consumer/test_kafka_consumer.py
+++ b/kafka_consumer/test_kafka_consumer.py
@@ -54,6 +54,7 @@ class TestKafka(AgentCheckTest):
         """
         nogroup_instance = copy.copy(instance)
         nogroup_instance[0].pop('consumer_groups')
+        nogroup_instance[0]['monitor_unlisted_consumer_groups'] = True
 
         self.run_check({'instances': instance})
 

--- a/kafka_consumer/test_kafka_consumer.py
+++ b/kafka_consumer/test_kafka_consumer.py
@@ -3,9 +3,10 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 # stdlib
-from nose.plugins.attrib import attr
+import copy
 
 # 3p
+from nose.plugins.attrib import attr
 
 # project
 from tests.checks.common import AgentCheckTest
@@ -39,6 +40,21 @@ class TestKafka(AgentCheckTest):
         """
         Testing Kafka_consumer check.
         """
+        self.run_check({'instances': instance})
+
+        for mname in METRICS:
+            self.assertMetric(mname, at_least=1)
+
+        self.coverage_report()
+
+
+    def test_check_nogroups(self):
+        """
+        Testing Kafka_consumer check grabbing groups from ZK
+        """
+        nogroup_instance = copy.copy(instance)
+        nogroup_instance[0].pop('consumer_groups')
+
         self.run_check({'instances': instance})
 
         for mname in METRICS:


### PR DESCRIPTION
### What does this PR do?

Will send an event when the consumer lag is negative, this is a bad scenario that should be traceable on the UI end.

### Motivation

Input from @jeffwidman 